### PR TITLE
Fix cannot use syscall.Stdin (type syscall.Handle) as type int in arg…

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -27,6 +27,12 @@
 
 [[projects]]
   branch = "master"
+  name = "golang.org/x/crypto"
+  packages = ["ssh/terminal"]
+  revision = "c7dcf104e3a7a1417abc0230cb0d5240d764159d"
+
+[[projects]]
+  branch = "master"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -45,6 +51,15 @@
     "jwt"
   ]
   revision = "2f32c3ac0fa4fb807a0fcefb0b6f2468a0d99bd0"
+
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/sys"
+  packages = [
+    "unix",
+    "windows"
+  ]
+  revision = "7dca6fe1f43775aa6d1334576870ff63f978f539"
 
 [[projects]]
   branch = "master"
@@ -77,6 +92,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "5d84450a906714e6d168a4b10e753a825d4cc64b33350aa0680622ec83db37f0"
+  inputs-digest = "458cc4bdaa2bb071120259d553bbd0dd96226cdb138cb5c709642a2ac68e9305"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/command.go
+++ b/command.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"strings"
-	"syscall"
 
 	"github.com/Mitu217/tamate/util"
 
@@ -263,35 +262,36 @@ func diffAction(c *cli.Context) {
 
 func generateConfig(configType string, outputPath string) (string, error) {
 	t := strings.ToLower(configType)
+	isStdinTerm := terminal.IsTerminal(0) // fd0: stdin
 	switch t {
 	case "sql":
 		server := config.ServerConfig{}
 		config := config.SQLConfig{Type: t}
-		if terminal.IsTerminal(syscall.Stdin) {
+		if isStdinTerm {
 			fmt.Print("DriverName: ")
 			fmt.Scan(&server.DriverName)
 		}
-		if terminal.IsTerminal(syscall.Stdin) {
+		if isStdinTerm {
 			fmt.Print("Host: ")
 			fmt.Scan(&server.Host)
 		}
-		if terminal.IsTerminal(syscall.Stdin) {
+		if isStdinTerm {
 			fmt.Print("Port: ")
 			fmt.Scan(&server.Port)
 		}
-		if terminal.IsTerminal(syscall.Stdin) {
+		if isStdinTerm {
 			fmt.Print("User: ")
 			fmt.Scan(&server.User)
 		}
-		if terminal.IsTerminal(syscall.Stdin) {
+		if isStdinTerm {
 			fmt.Print("Password: ")
 			fmt.Scan(&server.Password)
 		}
-		if terminal.IsTerminal(syscall.Stdin) {
+		if isStdinTerm {
 			fmt.Print("DatabaseName: ")
 			fmt.Scan(&config.DatabaseName)
 		}
-		if terminal.IsTerminal(syscall.Stdin) {
+		if isStdinTerm {
 			fmt.Print("TableName: ")
 			fmt.Scan(&config.TableName)
 		}
@@ -299,23 +299,23 @@ func generateConfig(configType string, outputPath string) (string, error) {
 		return config.Output(outputPath)
 	case "spreadsheets":
 		config := config.SpreadSheetsConfig{Type: t}
-		if terminal.IsTerminal(syscall.Stdin) {
+		if isStdinTerm {
 			fmt.Print("SpreadSheetsID: ")
 			fmt.Scan(&config.SpreadSheetsID)
 		}
 		// TODO: スペース入りの文字列が対応不可
-		if terminal.IsTerminal(syscall.Stdin) {
+		if isStdinTerm {
 			fmt.Print("SheetName: ")
 			fmt.Scan(&config.SheetName)
 		}
-		if terminal.IsTerminal(syscall.Stdin) {
+		if isStdinTerm {
 			fmt.Print("Range: ")
 			fmt.Scan(&config.Range)
 		}
 		return config.Output(outputPath)
 	case "csv":
 		config := config.CSVConfig{Type: t}
-		if terminal.IsTerminal(syscall.Stdin) {
+		if isStdinTerm {
 			fmt.Print("FilePath: ")
 			fmt.Scan(&config.Path)
 		}


### PR DESCRIPTION
```
.\command.go:270: cannot use syscall.Stdin (type syscall.Handle) as type int in argument to terminal.IsTerminal
.\command.go:274: cannot use syscall.Stdin (type syscall.Handle) as type int in argument to terminal.IsTerminal
.\command.go:278: cannot use syscall.Stdin (type syscall.Handle) as type int in argument to terminal.IsTerminal
.\command.go:282: cannot use syscall.Stdin (type syscall.Handle) as type int in argument to terminal.IsTerminal
.\command.go:286: cannot use syscall.Stdin (type syscall.Handle) as type int in argument to terminal.IsTerminal
.\command.go:290: cannot use syscall.Stdin (type syscall.Handle) as type int in argument to terminal.IsTerminal
.\command.go:294: cannot use syscall.Stdin (type syscall.Handle) as type int in argument to terminal.IsTerminal
.\command.go:302: cannot use syscall.Stdin (type syscall.Handle) as type int in argument to terminal.IsTerminal
.\command.go:307: cannot use syscall.Stdin (type syscall.Handle) as type int in argument to terminal.IsTerminal
.\command.go:311: cannot use syscall.Stdin (type syscall.Handle) as type int in argument to terminal.IsTerminal
.\command.go:311: too many errors
```
