### PR TITLE
Erase warning for dep

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -4,15 +4,7 @@
 [[projects]]
   branch = "master"
   name = "cloud.google.com/go"
-  packages = [
-    "civil",
-    "compute/metadata",
-    "internal/atomiccache",
-    "internal/fields",
-    "internal/protostruct",
-    "internal/version",
-    "spanner"
-  ]
+  packages = ["civil","compute/metadata","internal/atomiccache","internal/fields","internal/protostruct","internal/version","spanner"]
   revision = "90f2606161ee6a14efe2ca79fc05ac2b8efe250b"
 
 [[projects]]
@@ -23,165 +15,61 @@
 
 [[projects]]
   name = "github.com/golang/protobuf"
-  packages = [
-    "proto",
-    "protoc-gen-go/descriptor",
-    "ptypes",
-    "ptypes/any",
-    "ptypes/duration",
-    "ptypes/empty",
-    "ptypes/struct",
-    "ptypes/timestamp"
-  ]
+  packages = ["proto","protoc-gen-go/descriptor","ptypes","ptypes/any","ptypes/duration","ptypes/empty","ptypes/struct","ptypes/timestamp"]
   revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
   version = "v1.1.0"
 
 [[projects]]
   name = "go.opencensus.io"
-  packages = [
-    "internal",
-    "internal/tagencoding",
-    "plugin/ocgrpc",
-    "stats",
-    "stats/internal",
-    "stats/view",
-    "tag",
-    "trace",
-    "trace/internal",
-    "trace/propagation"
-  ]
+  packages = ["internal","internal/tagencoding","plugin/ocgrpc","stats","stats/internal","stats/view","tag","trace","trace/internal","trace/propagation"]
   revision = "10cec2c05ea2cfb8b0d856711daedc49d8a45c56"
   version = "v0.9.0"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = [
-    "context",
-    "context/ctxhttp",
-    "http/httpguts",
-    "http2",
-    "http2/hpack",
-    "idna",
-    "internal/timeseries",
-    "trace"
-  ]
+  packages = ["context","context/ctxhttp","http/httpguts","http2","http2/hpack","idna","internal/timeseries","trace"]
   revision = "2491c5de3490fced2f6cff376127c667efeed857"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/oauth2"
-  packages = [
-    ".",
-    "google",
-    "internal",
-    "jws",
-    "jwt"
-  ]
+  packages = [".","google","internal","jws","jwt"]
   revision = "cdc340f7c179dbbfa4afd43b7614e8fcadde4269"
 
 [[projects]]
   name = "golang.org/x/text"
-  packages = [
-    "collate",
-    "collate/build",
-    "internal/colltab",
-    "internal/gen",
-    "internal/tag",
-    "internal/triegen",
-    "internal/ucd",
-    "language",
-    "secure/bidirule",
-    "transform",
-    "unicode/bidi",
-    "unicode/cldr",
-    "unicode/norm",
-    "unicode/rangetable"
-  ]
+  packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable"]
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
   name = "google.golang.org/api"
-  packages = [
-    "gensupport",
-    "googleapi",
-    "googleapi/internal/uritemplates",
-    "internal",
-    "iterator",
-    "option",
-    "sheets/v4",
-    "transport/grpc"
-  ]
+  packages = ["gensupport","googleapi","googleapi/internal/uritemplates","internal","iterator","option","sheets/v4","transport/grpc"]
   revision = "d7aa31fbd7da4467a8056610e654315a4c1f068e"
 
 [[projects]]
   name = "google.golang.org/appengine"
-  packages = [
-    ".",
-    "cloudsql",
-    "internal",
-    "internal/app_identity",
-    "internal/base",
-    "internal/datastore",
-    "internal/log",
-    "internal/modules",
-    "internal/remote_api",
-    "internal/socket",
-    "internal/urlfetch",
-    "socket",
-    "urlfetch"
-  ]
+  packages = [".","cloudsql","internal","internal/app_identity","internal/base","internal/datastore","internal/log","internal/modules","internal/remote_api","internal/socket","internal/urlfetch","socket","urlfetch"]
   revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
   name = "google.golang.org/genproto"
-  packages = [
-    "googleapis/api/annotations",
-    "googleapis/rpc/errdetails",
-    "googleapis/rpc/status",
-    "googleapis/spanner/v1"
-  ]
+  packages = ["googleapis/api/annotations","googleapis/rpc/errdetails","googleapis/rpc/status","googleapis/spanner/v1"]
   revision = "7bb2a897381c9c5ab2aeb8614f758d7766af68ff"
 
 [[projects]]
   name = "google.golang.org/grpc"
-  packages = [
-    ".",
-    "balancer",
-    "balancer/base",
-    "balancer/roundrobin",
-    "channelz",
-    "codes",
-    "connectivity",
-    "credentials",
-    "credentials/oauth",
-    "encoding",
-    "encoding/proto",
-    "grpclb/grpc_lb_v1/messages",
-    "grpclog",
-    "internal",
-    "keepalive",
-    "metadata",
-    "naming",
-    "peer",
-    "resolver",
-    "resolver/dns",
-    "resolver/passthrough",
-    "stats",
-    "status",
-    "tap",
-    "transport"
-  ]
+  packages = [".","balancer","balancer/base","balancer/roundrobin","channelz","codes","connectivity","credentials","credentials/oauth","encoding","encoding/proto","grpclb/grpc_lb_v1/messages","grpclog","internal","keepalive","metadata","naming","peer","resolver","resolver/dns","resolver/passthrough","stats","status","tap","transport"]
   revision = "41344da2231b913fa3d983840a57a6b1b7b631a1"
   version = "v1.12.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "dc987f97d0b67f53760bc027f85a25c531d24c64d9533ab0dd6ee1d6bde8a33a"
+  inputs-digest = "d0632b544415260eedf2d6def9d9a531958233852f1b3509b98b50b121e946ff"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -51,38 +51,38 @@
 
 
 
-[[dependencies]]
+[[constraint]]
   branch = "master"
   name = "cloud.google.com/go"
 
-[[dependencies]]
+[[constraint]]
   branch = "master"
   name = "github.com/go-sql-driver/mysql"
 
-[[dependencies]]
+[[constraint]]
   name = "github.com/golang/protobuf"
   version = "^1.1.0"
 
-[[dependencies]]
+[[constraint]]
   name = "go.opencensus.io"
   version = ">=0.9.0, <1.0.0"
 
-[[dependencies]]
+[[constraint]]
   branch = "master"
   name = "golang.org/x/oauth2"
 
-[[dependencies]]
+[[constraint]]
   branch = "master"
   name = "google.golang.org/api"
 
-[[dependencies]]
+[[constraint]]
   name = "google.golang.org/appengine"
   version = "^1.0.0"
 
-[[dependencies]]
+[[constraint]]
   branch = "master"
   name = "google.golang.org/genproto"
 
-[[dependencies]]
+[[constraint]]
   name = "google.golang.org/grpc"
   version = "^1.12.0"


### PR DESCRIPTION
When I run `dep ensure`, dep output following warning:
dep: WARNING: Unknown field in manifest: dependencies

This may be similar to this dep issue:
https://github.com/golang/dep/issues/686
